### PR TITLE
soname changed in a micro release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,10 @@ source:
   sha256: 7b44340a3edc55c11abfc453bb60f148b29f569cef9e1148583e76132e9c7379
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   run_exports:
-    # https://github.com/conda-forge/libspatialindex-feedstock/pull/18#issuecomment-473935733
-    - {{ pin_subpackage('libspatialindex', max_pin='x.x') }}
+    - {{ pin_subpackage('libspatialindex', max_pin='x.x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
@hobu I only noticed this now due to https://github.com/conda-forge/qgis-feedstock/issues/92 bit 1.9.1 should've been 1.10.0 instead if we are trying to follow semver.