### PR TITLE
fix run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.3" %}
+{% set version = "1.9.0" %}
 
 package:
   name: libspatialindex
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://github.com/libspatialindex/libspatialindex/archive/{{ version }}.tar.gz
-  sha256: 7b44340a3edc55c11abfc453bb60f148b29f569cef9e1148583e76132e9c7379
+  sha256: 7c8809cd7e827efdc8bd80f786cf2a2d4f25adb92f954d46f7f28ad410bd46e2
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage('libspatialindex', max_pin='x.x.x') }}


### PR DESCRIPTION
Same as #22 for `1.9.0`. I'll remove the other build numbers after this one is merged and published.